### PR TITLE
Require manual invocation of `nest-cli` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "description": "An application for managing billing data for consulting projects",
   "main": "src/server/index.js",
   "scripts": {
-    "postinstall": "npm run get-secrets",
     "get-secrets": "nest get-secrets --prompt",
     "lint": "jshint src",
     "start": "node .",

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ environment. Instructions for each are provided below.
 Run:
 
     $ npm install
+    $ npm run get-secrets
 
 **Virtual Machine:**
 


### PR DESCRIPTION
This should not be included as an npm "post install" script because:
1. In addition to initially installing dependencies, the `npm install`
   command is used to update dependencies. Secrets do not need to be
   fetched in these cases.
2. Continuous integration services should be able to install
   dependencies in an automated fashion without the credentials required
   by the `nest-cli` script.

@Wilto sound good?
