### PR TITLE
Improve application bundle serving

### DIFF
--- a/src/server/serve-app.js
+++ b/src/server/serve-app.js
@@ -1,17 +1,13 @@
 'use strict';
 
 var fs = require('fs');
-var src;
-
-try {
-  src = fs.readFileSync('./app-production.js', { encoding: 'utf-8' });
-} catch(err) {
-  throw new Error(
-    'Unable to read production build of application. Please run `npm run ' +
-    'build`.'
-  );
-}
+var filePath = __dirname + '/../../app-production.js';
 
 module.exports = function(req, res) {
-  res.send(src);
+  fs.createReadStream(filePath).on('error', function() {
+    throw new Error(
+      'Unable to read production build of application. Please run `npm run ' +
+      'build`.'
+    );
+  }).pipe(res);
 };


### PR DESCRIPTION
Currently the app bundle source is cached for the lifetime of the
server.  It's loaded in synchronously and if errored, will throw an
exception at the initialization-time of the server.

This update does the following:

- Creates a file stream, so that the latest contents are always
  reflected in a request (no caching).
- The file stream `error` event is listened to and the same exception is
  triggered at runtime instead of load-time (is this a benefit or
  negative?).
- I changed the file path lookup to include `__dirname` so that if you
  decide to run the server from a different folder, it will always know
  where to find the actual bundle.