### PR TITLE
Hides the accessToken in the URL

### DIFF
--- a/src/client/modules/util/token.js
+++ b/src/client/modules/util/token.js
@@ -46,6 +46,9 @@ exports.get = function() {
     if (pair[0] === 'access_token') {
       value = pair[1];
       activeStore.set(pair[1]);
+
+      // Hide the token from the URL now.
+      history.replaceState('', {}, location.pathname);
     }
   });
 


### PR DESCRIPTION
Maintains a cleaner transition once logged in by hiding the access token
sent from the oauth callback.

Not sure if this is desired, but it irked me enough to update :deciduous_tree: