### PR TITLE
Correct input form for phaseless projects

### DIFF
--- a/src/client/modules/components/review-employee-row-day/index.js
+++ b/src/client/modules/components/review-employee-row-day/index.js
@@ -107,32 +107,35 @@ module.exports = Component.extend({
       }
     },
 
-    newProject: {
-      set: function(val) {
-        this.set('_newProject', val);
+    newProjectId: {
+      set: function(newId) {
+        var project;
+
+        this.get('activeProjects').some(function(activeProject) {
+          if (activeProject.id === newId) {
+            project = activeProject;
+            return true;
+          }
+        });
+
+        this.get('phaselessProjects').some(function(phaselessProject) {
+          if (phaselessProject.id === newId) {
+            project = phaselessProject;
+            return true;
+          }
+        });
+
+        this.set('_newProjectId', newId);
+        this.set('_newProject', project);
+        this.set('newPhase', null);
       },
       get: function() {
-        var newProject = this.get('_newProject');
-        var currentProjectId = this.get('utilization.project_id');
-        var activeProjects = this.get('activeProjects');
-
-        var type = this.get('newType');
-
-        if (!type || !type.project_required) {
-          return null;
-        }
-
-        if (!newProject && currentProjectId && activeProjects) {
-          activeProjects.some(function(project) {
-            if (project.id === currentProjectId) {
-              newProject = project;
-              return true;
-            }
-          });
-        }
-
-        return newProject;
+        return this.get('_newProjectId') || this.get('newProject.id');
       }
+    },
+
+    newProject: function() {
+      return this.get('_newProject') || this.get('utilization.project');
     },
 
     newPhase: {

--- a/src/client/modules/components/review-employee-row-day/template.html
+++ b/src/client/modules/components/review-employee-row-day/template.html
@@ -24,7 +24,7 @@
     {{#with utilization}}
     <span class="utilization-type">{{ type.name }}</span>
     {{#if type.project_required}}
-      <span class="utilization-project">{{ project.name }}</span>
+      <span class="utilization-project">{{ newProject.name }}</span>
       <span class="utilization-phase">{{ newPhase.name }}</span>
     {{/if}}
     {{/with}}
@@ -48,14 +48,14 @@
 
     <select id="{{dayName}}{{employee.id}}-project"
       {{#if !newType.project_required}}disabled{{/if}}
-      value="{{newProject}}">
+      value="{{newProjectId}}">
 
       <option selected disabled>Project</option>
       {{#each activeProjects}}
-      <option value="{{this}}">{{name}}</option>
+      <option value="{{id}}">{{name}}</option>
       {{/each}}
       {{#each phaselessProjects}}
-      <option value="{{this}}">{{name}}</option>
+      <option value="{{id}}">{{name}}</option>
       {{/each}}
     </select>
 

--- a/test/ui/driver/read-el.js
+++ b/test/ui/driver/read-el.js
@@ -1,0 +1,41 @@
+'use strict';
+
+function getSelectedOption(el) {
+  var selectedIndex;
+
+  return el.getProperty('selectedIndex').then(function(_selectedIndex) {
+      selectedIndex = _selectedIndex;
+
+      return el.findAllByTagName('option');
+    }).then(function(options) {
+      var selected = options[selectedIndex];
+
+      if (!selected) {
+        throw new Error(
+          'Cannot read a `select` element that has no value selected.'
+        );
+      }
+
+      return selected;
+    });
+}
+
+/**
+ * Read the visible text of a given Leadfoot/Element instance. If the element
+ * is a `select` input, read the text of the selected option.
+ *
+ * @param {Element} el The Leadfoot/Element instance to read
+ *
+ * @returns {string} The visible text
+ */
+module.exports = function(el) {
+  return el.getTagName().then(function(tagName) {
+      if (tagName.toLowerCase() === 'select') {
+        return getSelectedOption(el);
+      }
+
+      return el;
+    }).then(function(el) {
+      return el.getVisibleText();
+    });
+};

--- a/test/ui/selectors.json
+++ b/test/ui/selectors.json
@@ -29,6 +29,8 @@
             }
           },
           "typeInput": ".back select:nth-child(1)",
+          "projectInput": ".back select:nth-child(2)",
+          "phaseInput": ".back select:nth-child(3)",
           "set": ".back .set"
         }
       },

--- a/test/ui/tests/phase-review.js
+++ b/test/ui/tests/phase-review.js
@@ -49,6 +49,32 @@ describe('phase review', function() {
         }).then(function(phases) {
           assert.equal(phases[0], 'Make pudding');
           assert.equal(phases[6], 'Extract pudding skin');
+
+          return driver.viewUtilizationForm({
+            name: 'Jerry Seinfeld',
+            day: 'thursday'
+          });
+        }).then(function() {
+          return driver.readUtilizationForm({
+            name: 'Jerry Seinfeld',
+            day: 'thursday'
+          });
+        }).then(function(text) {
+          assert.equal(
+            text.type,
+            'Education',
+            'Form renders correctly when initialized with a phaseless project'
+          );
+          assert.equal(
+            text.project,
+            'Fundraising Drive',
+            'Form renders correctly when initialized with a phaseless project'
+          );
+          assert.equal(
+            text.phase,
+            'Select Phase',
+            'Form renders correctly when initialized with a phaseless project'
+          );
         });
     });
 


### PR DESCRIPTION
The "project phase" input options are serialized from multiple responses. This means that the strict equality operator cannot be reliably used to compare the likeness of a "phase" input option and a utilization model's "phase" attribute.

Phase model ID values are primitive JavaScript numbers that describe the identity of the phase. This makes them suitable for comparison across objects that, despite being distinct in memory, describe the same "phase" model.

Update the "edit utilization" form to initialize its values according to model IDs, not model objects.