### PR TITLE
[Fix] Correct behavior of drag-and-drop

### DIFF
--- a/src/client/modules/components/review-employee-row-day/index.js
+++ b/src/client/modules/components/review-employee-row-day/index.js
@@ -8,6 +8,13 @@ module.exports = Component.extend({
 
   oninit: function() {
     this.observe('newProjectId', this.handleNewProjectIdChange);
+
+    // Ensure that whenever the `utilization` attribute is updated directly (as
+    // in this view's `setAndSave` method), the view's `projectId` is likewise
+    // updated).
+    this.observe('utilization', function() {
+      this.set('newProjectId', null);
+    });
   },
 
   read: function() {


### PR DESCRIPTION
Ensure that the "utilization day" view is properly updated when it is
the drop target of a utilization with the same utilization type.