### PR TITLE
[Fix] "Unverify" developer weeks dynamically

### DIFF
--- a/src/client/modules/components/review-employee-row-day/index.js
+++ b/src/client/modules/components/review-employee-row-day/index.js
@@ -31,27 +31,6 @@ module.exports = Component.extend({
     };
   },
 
-  setAndSave: function(date, values) {
-    var utilizations = this.get('utilizations');
-    var old = utilizations.atDate(date);
-    var current = utilizations.setAtDate(date, values, { silent: true });
-
-    this.set('isSaving', true);
-
-    utilizations.save().then(function() {
-        this.set('isSaving', false);
-        this.set('utilization', current);
-      }.bind(this), function(err) {
-        this.set('isSaving', false);
-        utilizations.setAtDate(date, old, { silent: true });
-        this.set('utilization', old);
-
-        this.fire('error', {
-          title: 'Failed to save utilization', desc: err
-        });
-      }.bind(this));
-  },
-
   handleDragstart: function() {
     var event = this.event;
 
@@ -212,7 +191,7 @@ module.exports = Component.extend({
           return;
         }
 
-        this.setAndSave(date, this.read());
+        this.fire('set', this, date, this.read());
       }
     }
   }

--- a/src/client/modules/components/review-employee-row/index.js
+++ b/src/client/modules/components/review-employee-row/index.js
@@ -14,6 +14,7 @@ module.exports = Component.extend({
     this.on('wr-employee-row-day.select', this.selectUtilization.bind(this));
     this.on('wr-employee-row-day.deselect', this.deselectUtilization.bind(this));
     this.on('wr-employee-row-day.brush', this.brushUtilization.bind(this));
+    this.on('wr-employee-row-day.set', this.setUtilization.bind(this));
   },
 
   computed: {
@@ -66,12 +67,35 @@ module.exports = Component.extend({
     this.selected = utilization.createMatching();
   },
 
+  setUtilization: function(component, date, values) {
+    var utilizations = this.get('utilizations');
+    var old = utilizations.atDate(date);
+    var current = utilizations.setAtDate(date, values, { silent: true });
+    var done = function() {
+      this.update('utilizations');
+      component.set('isSaving', false);
+    }.bind(this);
+
+    current.set('verified', false, { silent: true });
+    component.set('isSaving', true);
+
+    utilizations.save().then(function() {
+        component.set('utilization', current);
+      }.bind(this), function(err) {
+        utilizations.setAtDate(date, old, { silent: true });
+
+        this.fire('error', {
+          title: 'Failed to save utilization', desc: err
+        });
+      }.bind(this)).then(done, done);
+  },
+
   brushUtilization: function(component, date) {
     if (!this.selected) {
       return;
     }
 
-    component.setAndSave(date, this.selected);
+    this.setUtilization(component, date, this.selected);
   },
 
   deselectUtilization: function() {

--- a/src/client/modules/components/review-employee-row/template.html
+++ b/src/client/modules/components/review-employee-row/template.html
@@ -23,7 +23,6 @@
     activeProjects="{{activeProjects}}"
     phaselessProjects="{{phaselessProjects}}"
     utilization="{{utilizations.atDay(date, offset + 1)}}"
-    utilizations="{{utilizations}}"
     utilizationTypes="{{utilizationTypes}}"
     weekStart="{{date}}" />
   {{/each}}

--- a/test/ui/driver/index.js
+++ b/test/ui/driver/index.js
@@ -331,6 +331,17 @@ Driver.prototype.editUtilization = function(options) {
   var driver = this;
   var offset;
 
+  function whenSaved() {
+    return waitFor(function() {
+        return driver._$('phaseWeek.day.saving')
+          .then(function(savingEls) {
+            return savingEls[offset].isDisplayed();
+          }).then(function(isDisplayed) {
+            return !isDisplayed;
+          });
+      });
+  }
+
   return this.viewUtilizationForm(options).then(function(_offset) {
       offset = _offset;
 
@@ -341,7 +352,7 @@ Driver.prototype.editUtilization = function(options) {
       return driver._$('phaseWeek.day.set');
     }).then(function(set) {
       return set[offset].click();
-    });
+    }).then(whenSaved);
 };
 
 /**

--- a/test/ui/selectors.json
+++ b/test/ui/selectors.json
@@ -31,6 +31,7 @@
           "typeInput": ".back select:nth-child(1)",
           "projectInput": ".back select:nth-child(2)",
           "phaseInput": ".back select:nth-child(3)",
+          "saving": ".saving",
           "set": ".back .set"
         }
       },

--- a/test/ui/tests/phase-review.js
+++ b/test/ui/tests/phase-review.js
@@ -148,7 +148,7 @@ describe('phase review', function() {
     it('correctly splits an existing multi-day utilization', function() {
       var hasPut = false;
       function handlePut(req, res) {
-        assert.equal(req.params.id, 4);
+        assert.equal(req.params.id, 7);
         hasPut = true;
         res.end();
       }
@@ -162,11 +162,20 @@ describe('phase review', function() {
           middleMan.once('POST', '/utilizations', handlePost),
           middleMan.once('POST', '/utilizations', handlePost),
           driver.editUtilization({
-            name: 'Jerry Seinfeld',
+            name: 'Cosmo Kramer',
             day: 'tuesday',
             type: 'Vacation'
           })
-        ]);
+        ]).then(function() {
+          return driver.count('phaseWeek.verified');
+        }).then(function(count) {
+          assert.equal(
+            count,
+            0,
+            'Developer weeks become "unverified" when utilization data is ' +
+              'changed'
+          );
+        });
     });
 
     it('correctly submits a review', function() {

--- a/test/unit/tests/models/abstract/json-api-model.js
+++ b/test/unit/tests/models/abstract/json-api-model.js
@@ -30,6 +30,12 @@ suite('JsonApiModel', function() {
       assert.equal(person.isDirty(), false);
     });
 
+    test('initially clean (when created with attributes)', function() {
+      var person2 = new SyncPerson({ first: 'karen' });
+
+      assert.equal(person2.isDirty(), false);
+    });
+
     test('dirtied by setting attribute', function() {
       person.set('first', 'mark');
 
@@ -42,24 +48,16 @@ suite('JsonApiModel', function() {
       assert.equal(person.isDirty(), true);
     });
 
-    /**
-     * This test represents an edge case not supported by the current
-     * implementation of the `isDirty` method. Addressing it may require
-     * overriding `AmpersandModel#set` to address (an inherently brittle
-     * approach because multiple Ampersand Model methods can modify state, and
-     * their is not guaruntee that they will use the `set` method internally).
-     * TODO: Address the underlying problem and enable this test.
-     */
-    test.skip('dirtied by setting attribute "silently" twice', function() {
-      person.set('first', 'mark', { silent: true });
-      person.set('first', 'mark', { silent: true });
+    test('still dirty after re-setting attribute to same value', function() {
+      person.set('first', 'mark');
+      person.set('first', 'mark');
 
       assert.equal(person.isDirty(), true);
     });
 
-    test('still dirty after re-setting attribute to same value', function() {
-      person.set('first', 'mark');
-      person.set('first', 'mark');
+    test('dirtied by setting attribute "silently" twice', function() {
+      person.set('first', 'mark', { silent: true });
+      person.set('first', 'mark', { silent: true });
 
       assert.equal(person.isDirty(), true);
     });
@@ -68,6 +66,15 @@ suite('JsonApiModel', function() {
       person.set('first', 'matt');
 
       return person.save().then(function() {
+          assert.equal(person.isDirty(), false);
+        });
+    });
+
+    test('clean after setting to identical value', function() {
+      person.set('first', 'matt');
+
+      return person.save().then(function() {
+          person.set('first', 'matt');
           assert.equal(person.isDirty(), false);
         });
     });


### PR DESCRIPTION
When utilization data changes, re-set the "verified" attribute to
`false`. Ensure that the "Verified" button in the UI updates
accordingly.

This necessitated a few changes:

- Addressing a long-standing bug with detecting model "dirtiness" (this
  depends on a somewhat brittle heuristic)
- Explicit avoidance of a previously-existing race condition in the UI
  tests
- Re-structuring the view components for developer weeks and developer
  days. The "developer week" view is now soley responsible for
  utilization collections, and the "developer day" view only has
  knowledge of a single utilization model at a time. In addition to
  facilitating the new functionality, this cleaner separation of
  responsibilities is less prone to errors (in the from of UI thrasing)
  and hopefully makes the application logic easier to reason about.