### PR TITLE
[Fix] Respect DST boundaries

### DIFF
--- a/src/client/modules/components/review-employee-row/template.html
+++ b/src/client/modules/components/review-employee-row/template.html
@@ -22,7 +22,7 @@
     activePhases="{{activePhases}}"
     activeProjects="{{activeProjects}}"
     phaselessProjects="{{phaselessProjects}}"
-    utilization="{{utilizations.atDay(date, offset + 1)}}"
+    utilization="{{utilizations.atDate(date, offset + 1)}}"
     utilizationTypes="{{utilizationTypes}}"
     weekStart="{{date}}" />
   {{/each}}

--- a/src/client/modules/models/utilizations.js
+++ b/src/client/modules/models/utilizations.js
@@ -5,7 +5,8 @@ var extend = require('lodash.assign');
 var JsonApiCollection = require('./abstract/json-api-collection');
 var Utilization = require('./utilization');
 
-var ONE_DAY = 1000 * 60 * 60 * 24;
+var ONE_HOUR = 1000 * 60 * 60;
+var ONE_DAY = ONE_HOUR * 24;
 
 module.exports = JsonApiCollection.extend({
   model: Utilization,
@@ -92,10 +93,6 @@ module.exports = JsonApiCollection.extend({
    */
   atDate: function(date, offset) {
     return atDate(this.models, date, offset);
-  },
-
-  atDay: function(first, offset) {
-    return this.atDate(new Date(first.getTime() + offset * ONE_DAY));
   },
 
   /**
@@ -301,10 +298,12 @@ module.exports = JsonApiCollection.extend({
  * @returns {Utilization|null}
  */
 function atDate(models, date, offset) {
+  var hours = date.getHours();
   var idx, length, current;
 
   if (offset) {
-    date = new Date(date.getTime() + offset * ONE_DAY);
+    date = new Date(date.getTime() + offset * ONE_DAY + ONE_HOUR);
+    date.setHours(hours);
   }
 
   for (idx = 0, length = models.length; idx < length; ++idx) {

--- a/test/unit/tests/models/utilizations.js
+++ b/test/unit/tests/models/utilizations.js
@@ -282,6 +282,42 @@ suite('Utilizations collection', function() {
       assert.equal(u.atDate(new Date(2012, 2, 2), 6), u.at(2));
       assert.equal(u.atDate(new Date(2012, 2, 2), 7), u.at(2));
     });
+
+    test('with offset (into DST)', function() {
+      var u = new Utilizations([
+        { first_day: new Date(2015, 2, 6), last_day: new Date(2015, 2, 9) },
+        { first_day: new Date(2015, 2, 10), last_day: new Date(2015, 2, 11) }
+      ]);
+
+      assert.equal(u.atDate(new Date(2015, 2, 7), 1), u.at(0));
+      assert.equal(u.atDate(new Date(2015, 2, 7), 2), u.at(0));
+      assert.equal(u.atDate(new Date(2015, 2, 7), 3), u.at(1));
+      assert.equal(u.atDate(new Date(2015, 2, 7), 4), u.at(1));
+      assert.equal(u.atDate(new Date(2015, 2, 7), 5), null);
+
+      assert.equal(u.atDate(new Date(2015, 2, 8), 1), u.at(0));
+      assert.equal(u.atDate(new Date(2015, 2, 8), 2), u.at(1));
+      assert.equal(u.atDate(new Date(2015, 2, 8), 3), u.at(1));
+      assert.equal(u.atDate(new Date(2015, 2, 8), 4), null);
+    });
+
+    test('with offset (out of DST)', function() {
+      var u = new Utilizations([
+        { first_day: new Date(2015, 9, 30), last_day: new Date(2015, 10, 2) },
+        { first_day: new Date(2015, 10, 3), last_day: new Date(2015, 10, 4) }
+      ]);
+
+      assert.equal(u.atDate(new Date(2015, 9, 31), 1), u.at(0));
+      assert.equal(u.atDate(new Date(2015, 9, 31), 2), u.at(0));
+      assert.equal(u.atDate(new Date(2015, 9, 31), 3), u.at(1));
+      assert.equal(u.atDate(new Date(2015, 9, 31), 4), u.at(1));
+      assert.equal(u.atDate(new Date(2015, 9, 31), 5), null);
+
+      assert.equal(u.atDate(new Date(2015, 10, 1), 1), u.at(0));
+      assert.equal(u.atDate(new Date(2015, 10, 1), 2), u.at(1));
+      assert.equal(u.atDate(new Date(2015, 10, 1), 3), u.at(1));
+      assert.equal(u.atDate(new Date(2015, 10, 1), 4), null);
+    });
   });
 
   suite('#setAtDate', function() {


### PR DESCRIPTION
Account for daylight savings time when calculating whole-day offsets in
Date values, and honor the original hour offset in all cases.

- When the offset transitions into daylight savings time, the actual
  calculation should add one fewer hours to the input time.
- When the offset transitions out of daylight savings time, the actual
  calculation should effectively add one additional hour to the input
  time.

Additionally, update the UI to re-use this logic consistently.