### PR TITLE
Update Firefox

### DIFF
--- a/deploy/ansible/roles/development/tasks/main.yml
+++ b/deploy/ansible/roles/development/tasks/main.yml
@@ -40,7 +40,7 @@
 # releases occasionally break Selenium integration.
 - name: Download Firefox
   get_url:
-    url=http://download.cdn.mozilla.net/pub/mozilla.org/firefox/releases/34.0/linux-x86_64/en-US/firefox-34.0.tar.bz2
+    url=http://download.cdn.mozilla.net/pub/mozilla.org/firefox/releases/37.0/linux-x86_64/en-US/firefox-37.0.tar.bz2
     dest=/tmp/firefox.tar.bz2
 
 - name: Create directory for Firefox

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "leadfoot": "^1.2.1",
     "path-to-regexp": "^1.0.2",
     "replay": "^1.12.0",
-    "selenium-binaries": "^0.2.0",
+    "selenium-binaries": "^0.3.6",
     "sinon": "^1.12.1",
     "wordwrap": "0.0.2"
   },

--- a/src/client/modules/components/review-employee-row-day/template.html
+++ b/src/client/modules/components/review-employee-row-day/template.html
@@ -28,15 +28,6 @@
       <span class="utilization-phase">{{ newPhase.name }}</span>
     {{/if}}
     {{/with}}
-
-    {{!
-      The latest version of Firefox (version 34 at the time of this writing)
-      exhibits a bug where `<label>` elements with the `draggable` attribute will
-      not initiate a `dragstart` event. Because the children of such elements will
-      correctly trigger that event on their parent, create an invisible element
-      that completely occupies the space of the parent.
-    }}
-    <div class="firefox-drag-workaround"></div>
   </label>
 
   <div class="back">


### PR DESCRIPTION
Remove a testing workaround that has been obviated by the latest release
of the browser.