### PR TITLE
[Feature] Allow setting project unconditionally

### DIFF
--- a/src/client/modules/components/review-employee-row-day/index.js
+++ b/src/client/modules/components/review-employee-row-day/index.js
@@ -19,15 +19,14 @@ module.exports = Component.extend({
 
   read: function() {
     var type = this.get('newType');
-    var projectRequired = type.get('project_required');
 
     return {
       utilization_type_id: type.get('id'),
       type: type.toJSON()['utilization-types'],
       employee_id: this.get('employee.id'),
-      project_id: projectRequired ? this.get('newProject.id') : 1,
-      project_phase_id: projectRequired ? this.get('newPhase.id') : null,
-      project: projectRequired ? this.get('newProject') : null
+      project_id: this.get('newProject.id'),
+      project_phase_id: this.get('newPhase.id'),
+      project: this.get('newProject')
     };
   },
 

--- a/src/client/modules/components/review-employee-row-day/index.js
+++ b/src/client/modules/components/review-employee-row-day/index.js
@@ -7,13 +7,14 @@ module.exports = Component.extend({
   css: require('./style.css'),
 
   oninit: function() {
+    this.set('newProjectId', this.get('utilization.project.id'));
     this.observe('newProjectId', this.handleNewProjectIdChange);
 
     // Ensure that whenever the `utilization` attribute is updated directly (as
     // in this view's `setAndSave` method), the view's `projectId` is likewise
     // updated).
     this.observe('utilization', function() {
-      this.set('newProjectId', null);
+      this.set('newProjectId', this.get('utilization.project.id'));
     });
   },
 
@@ -54,13 +55,8 @@ module.exports = Component.extend({
   },
 
   handleNewProjectIdChange: function(id) {
-    // The new project ID should default to the value of the current
-    // utilization's project.
-    if (!id) {
-      this.set('newProjectId', this.get('utilization.project.id'));
-
     // The phase should be un-set whenever the project changes
-    } else {
+    if (id) {
       this.set('newPhase', null);
     }
   },
@@ -113,6 +109,10 @@ module.exports = Component.extend({
       var phaselessProjects = this.get('phaselessProjects');
       var newId = this.get('newProjectId');
       var project;
+
+      if (!newId) {
+        return null;
+      }
 
       if (activeProjects) {
         activeProjects.some(function(activeProject) {

--- a/src/client/modules/components/review-employee-row-day/template.html
+++ b/src/client/modules/components/review-employee-row-day/template.html
@@ -42,7 +42,10 @@
     <select id="{{dayName}}{{employee.id}}-project"
       value="{{newProjectId}}">
 
-      <option selected disabled>Project</option>
+      <option selected
+        {{#if newType.project_required }}disabled{{/if}}
+        value="{{ null }}"
+        >Project</option>
       {{#each activeProjects}}
       <option value="{{id}}">{{name}}</option>
       {{/each}}

--- a/src/client/modules/components/review-employee-row-day/template.html
+++ b/src/client/modules/components/review-employee-row-day/template.html
@@ -23,9 +23,11 @@
 
     {{#with utilization}}
     <span class="utilization-type">{{ type.name }}</span>
-    {{#if type.project_required}}
+    {{#if newProject.name}}
       <span class="utilization-project">{{ newProject.name }}</span>
-      <span class="utilization-phase">{{ newPhase.name }}</span>
+      {{#if newPhase.name}}
+        <span class="utilization-phase">{{ newPhase.name }}</span>
+      {{/if}}
     {{/if}}
     {{/with}}
   </label>
@@ -38,7 +40,6 @@
     </select>
 
     <select id="{{dayName}}{{employee.id}}-project"
-      {{#if !newType.project_required}}disabled{{/if}}
       value="{{newProjectId}}">
 
       <option selected disabled>Project</option>
@@ -51,7 +52,7 @@
     </select>
 
     <select id="{{dayName}}{{employee.id}}-phase"
-      {{#if !newType.project_required || !phases.length}}disabled{{/if}}
+      {{#if !phases.length}}disabled{{/if}}
       value="{{newPhase}}">
 
       {{! TODO: Remove the value assigned to the `disabled` attribute once the


### PR DESCRIPTION
Recent changes in users' needs has made it necessary to set the
"project" even on utilizations that do not require it. Relax
restrictions on utilization modification to allow this.

Resolves gh-98 .